### PR TITLE
Fix unit tests failing randomly

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -10,6 +10,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ErrorResponseMonitorModule } from './error-response-monitor/error-response-monitor.module';
 import { MonitoringSelectionModule } from './monitoring-selection/monitoring-selection.module';
 import { FormsModule } from '@angular/forms';
+import { APP_BASE_HREF } from '@angular/common';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -20,11 +21,14 @@ describe('AppComponent', () => {
         AppRoutingModule,
         BrowserAnimationsModule,
         MaterialModule,
-        HttpClientModule,
         ErrorResponseMonitorModule,
         MonitoringSelectionModule,
         FormsModule,
       ],
+      providers: [
+        // fix test sometimes failing in debug mode of jasmin
+        { provide: APP_BASE_HREF, useValue : '/' }
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/cpu-utilization-monitor/cpu-observer-list/cpu-observer-list.component.spec.ts
+++ b/src/app/cpu-utilization-monitor/cpu-observer-list/cpu-observer-list.component.spec.ts
@@ -11,6 +11,7 @@ import { MaterialModule } from 'src/app/material.module';
 import { CpuUtilizationMonitorRoutes } from '../cpu-utilization-monitor.routes';
 import { SocketIoModule, SocketIoConfig } from 'ngx-socket-io';
 import { ReactiveFormsModule } from '@angular/forms';
+import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 
 const config: SocketIoConfig = {
   url: "http://localhost:3100",
@@ -19,6 +20,7 @@ const config: SocketIoConfig = {
 describe('CpuObserverListComponent', () => {
   let component: CpuObserverListComponent;
   let fixture: ComponentFixture<CpuObserverListComponent>;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -33,22 +35,27 @@ describe('CpuObserverListComponent', () => {
         CpuUtilizationMonitorRoutes,
         SocketIoModule.forRoot(config),
         ReactiveFormsModule,
-        HttpClientModule,
+        HttpClientTestingModule,
         MatDialogModule
       ],
       providers: [
         EndpoitsService
       ]
-    }).compileComponents();
+    }).compileComponents().then(() => {
+      httpTestingController = TestBed.get(HttpTestingController);
+      fixture = TestBed.createComponent(CpuObserverListComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
   }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(CpuObserverListComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+
+    // I don't know where the call to this url actually comes from when executing this test!
+    // The socket.io module import can be commented out and the test still works...
+    httpTestingController.expectOne(
+      'http://localhost:3100/'
+    ).flush('');
   });
 });

--- a/src/app/cpu-utilization-monitor/edit-observation-endpoint/edit-observation-endpoint.component.spec.ts
+++ b/src/app/cpu-utilization-monitor/edit-observation-endpoint/edit-observation-endpoint.component.spec.ts
@@ -23,14 +23,12 @@ describe('EditObservationEndpointComponent', () => {
         FormBuilder,
         { provide: CpuObservationEndpoint, useValue: {} },
       ],
-    }).compileComponents();
+    }).compileComponents().then(() => {
+      fixture = TestBed.createComponent(EditObservationEndpointComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
   }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EditObservationEndpointComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/error-response-monitor/error-response-monitor.component.spec.ts
+++ b/src/app/error-response-monitor/error-response-monitor.component.spec.ts
@@ -2,26 +2,30 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ErrorResponseMonitorComponent } from './error-response-monitor.component';
 import { MatDialogModule } from '@angular/material/dialog';
-import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { ErrorResponseMonitorService } from './error-response-monitor.service';
+import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ErrorResponseMonitorComponent', () => {
   let component: ErrorResponseMonitorComponent;
   let fixture: ComponentFixture<ErrorResponseMonitorComponent>;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ErrorResponseMonitorComponent],
-      imports: [MatDialogModule, HttpClientModule, FormsModule],
+      imports: [MatDialogModule, HttpClientTestingModule, FormsModule],
       providers: [ErrorResponseMonitorService],
-    }).compileComponents();
+    }).compileComponents().then(() => {
+      httpTestingController = TestBed.get(HttpTestingController);
+      fixture = TestBed.createComponent(ErrorResponseMonitorComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ErrorResponseMonitorComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should create', () => {

--- a/src/app/error-response-monitor/error-response-monitor.service.spec.ts
+++ b/src/app/error-response-monitor/error-response-monitor.service.spec.ts
@@ -16,8 +16,12 @@ describe('ErrorResponseMonitorService', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
     });
-    service = TestBed.inject(ErrorResponseMonitorService);
     httpMock = TestBed.get(HttpTestingController);
+    service = TestBed.inject(ErrorResponseMonitorService);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {

--- a/src/app/monitoring-selection/monitoring-selection.service.spec.ts
+++ b/src/app/monitoring-selection/monitoring-selection.service.spec.ts
@@ -1,19 +1,31 @@
 import { TestBed } from '@angular/core/testing';
 import { MonitoringSelectionDTO } from './dto/monitoring-selection.dto';
 import { MonitoringSelectionService } from './monitoring-selection.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 describe('MonitoringSelectionService', () => {
   let service: MonitoringSelectionService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [MonitoringSelectionService],
       imports: [HttpClientTestingModule],
     });
+
+    httpTestingController = TestBed.get(HttpTestingController);
     service = TestBed.inject(MonitoringSelectionService);
   });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
   it('should be created', () => {
     expect(service).toBeTruthy();
+
+    httpTestingController.expectOne(
+      'http://localhost:3400/monitoring-selection'
+    ).flush('[]');
   });
 });

--- a/src/app/monitoring-selection/selection-item/selection-item.component.spec.ts
+++ b/src/app/monitoring-selection/selection-item/selection-item.component.spec.ts
@@ -3,21 +3,43 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelectionItemComponent } from './selection-item.component';
 import { MatDialogModule } from '@angular/material/dialog';
 import { HttpClientModule } from '@angular/common/http';
+import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('SelectionItemComponent', () => {
   let component: SelectionItemComponent;
   let fixture: ComponentFixture<SelectionItemComponent>;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SelectionItemComponent],
-      imports: [MatDialogModule, HttpClientModule],
-    }).compileComponents();
+      imports: [
+        MatDialogModule,
+        HttpClientTestingModule,
+      ],
+    }).compileComponents().then(() => {
+      httpTestingController = TestBed.get(HttpTestingController);
+      fixture = TestBed.createComponent(SelectionItemComponent);
+      component = fixture.componentInstance;
+      component.monitorSelection = {
+        name: 'Hello World',
+        _id: 'something',
+        serviceUrl: 'http://example.com',
+      };
+      fixture.detectChanges();
+    });
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SelectionItemComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  afterEach(() => {
+    httpTestingController.verify();
   });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+
+    httpTestingController.expectOne(
+      'http://localhost:3400/monitoring-selection'
+    ).flush('[]');
+  });
+
 });

--- a/src/app/monitoring-selection/selection-list/selection-list.component.spec.ts
+++ b/src/app/monitoring-selection/selection-list/selection-list.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SelectionListComponent } from './selection-list.component';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { SelectionItemComponent } from '../selection-item/selection-item.component';
 import { EditSelectionComponent } from '../edit-selection/edit-selection.component';
 import { MaterialModule } from 'src/app/material.module';
@@ -10,21 +10,32 @@ import { MaterialModule } from 'src/app/material.module';
 describe('SelectionListComponent', () => {
   let component: SelectionListComponent;
   let fixture: ComponentFixture<SelectionListComponent>;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SelectionListComponent, SelectionItemComponent, EditSelectionComponent],
-      imports: [MaterialModule, HttpClientTestingModule],
-    }).compileComponents();
+      imports: [
+        MaterialModule,
+        HttpClientTestingModule,
+      ],
+    }).compileComponents().then(() => {
+      httpTestingController = TestBed.get(HttpTestingController);
+      fixture = TestBed.createComponent(SelectionListComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SelectionListComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+
+    httpTestingController.expectOne(
+      'http://localhost:3400/monitoring-selection'
+    ).flush('[]');
   });
 });


### PR DESCRIPTION
Should fix all randomly failing unit tests.

Resources used for fixing the tests:

https://stackoverflow.com/questions/53208610/karma-test-random-test-fails-when-using-async-in-other-tests
https://stackoverflow.com/a/46328701
https://medium.com/better-programming/testing-http-requests-in-angular-with-httpclienttestingmodule-3880ceac74cf

The only two things I know for sure I fixed are the missing base href when running the app component unit test in debug mode and all unit tests where an api call was made by some service.

In one test I could not determine where the http call was issued! (marked with a comment in the test)
In all tests I applied the refactoring from the first stackoverflow link without knowing if that helped at all...

The unit tests worked consistently for me. Did not look at e2e tests.